### PR TITLE
GitHub Actionsのトリガー条件を修正

### DIFF
--- a/.github/workflows/ai-bot.yml
+++ b/.github/workflows/ai-bot.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ai-reply:
-    if: contains(github.event.comment.body, '@ai')
+    if: contains(github.event.comment.body, 'ai-by-shinshi')
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
---
タイトル: GitHub Actionsのトリガー条件を修正

本文: コメント内の特定のトリガーワードを検出する条件を、からに変更しました。この変更により、意図したトリガー条件に合致するコメントに対してのみワークフローが実行されるようになります。
---