### PR TITLE
Node.jsのバージョンを23.11.0に更新

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 23.0.0
+nodejs 23.11.0
 pnpm 9.15.9


### PR DESCRIPTION
---
タイトル: Node.jsのバージョンを23.11.0に更新
本文: Node.jsのバージョンを23.0.0から23.11.0に更新しました。これにより、最新の機能やセキュリティ修正が反映されるため、安定性と安全性を向上させる目的があります。他の依存環境には影響を与えません。
---