### PR TITLE
fix: PRタイトルと説明文生成のためGitHub workflowを修正

### DIFF
--- a/.github/workflows/ai-pr-description.yml
+++ b/.github/workflows/ai-pr-description.yml
@@ -17,6 +17,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Extract branch prefix
+        id: prefix
+        run: |
+          BRANCH_NAME="${{ github.head_ref }}"
+          if [[ $BRANCH_NAME =~ ^(feat|fix|chore|docs|style|refactor|perf|test|remove)/ ]]; then
+            PREFIX="${BASH_REMATCH[1]}"
+          else
+            PREFIX="chore"
+          fi
+          echo "prefix=$PREFIX" >> $GITHUB_OUTPUT
+
       - name: Get PR Diff
         id: diff
         run: |
@@ -31,15 +42,23 @@ jobs:
         uses: actions/ai-inference@v1
         with:
           prompt: |
-            以下はPull Requestの差分です。この内容から、わかりやすい日本語のPRタイトル・説明文をそれぞれ生成してください。
-            - タイトル: PRの要点を一言で書いてください
-            - 本文: 何を・なぜ・どのように変更したかを簡潔に書いてください
-            出力フォーマットは
+            以下はPull Requestの差分です。この内容から、以下の形式でPRのタイトルと説明文を生成してください。
+
+            【制約事項】
+            - タイトル: "${{ steps.prefix.outputs.prefix }}: " で始まる一行の文章
+            - 本文: 「実装内容」という見出しの下に、変更内容を箇条書きで記載
+            - 各箇条書きの項目は "${{ steps.prefix.outputs.prefix }}: " で始める
+            - 説明は簡潔に
+
+            【出力フォーマット】
             ---
-            タイトル: <タイトル> 
-            本文: <説明文>
+            タイトル: ${{ steps.prefix.outputs.prefix }}: <タイトルの残りの部分>
+            本文:
+            実装内容
+
+            - ${{ steps.prefix.outputs.prefix }}: <変更内容1>
+            - ${{ steps.prefix.outputs.prefix }}: <変更内容2（必要な場合は追加していく）>
             ---
-            でお願いします。
 
             差分:
             ${{ steps.diff.outputs.diff }}
@@ -49,7 +68,9 @@ jobs:
         run: |
           echo "${{ steps.ai.outputs.response }}" > pr_body.txt
           TITLE=$(grep '^タイトル:' pr_body.txt | sed 's/タイトル: //')
+          BODY=$(sed '1,/^本文:/d' pr_body.txt)
           echo "$TITLE" > pr_title.txt
+          echo "$BODY" > pr_body.txt
 
       - name: Update PR Title & Body (gh cli)
         run: |

--- a/.github/workflows/ai-pr-description.yml
+++ b/.github/workflows/ai-pr-description.yml
@@ -43,21 +43,23 @@ jobs:
         with:
           prompt: |
             以下はPull Requestの差分です。この内容から、以下の形式でPRのタイトルと説明文を生成してください。
+            必ず日本語で出力してください。
 
             【制約事項】
-            - タイトル: "${{ steps.prefix.outputs.prefix }}: " で始まる一行の文章
+            - タイトル: "${{ steps.prefix.outputs.prefix }}: " で始まる一行の日本語の文章
             - 本文: 「実装内容」という見出しの下に、変更内容を箇条書きで記載
             - 各箇条書きの項目は "${{ steps.prefix.outputs.prefix }}: " で始める
             - 説明は簡潔に
+            - すべての説明は日本語で記述する
 
             【出力フォーマット】
             ---
-            タイトル: ${{ steps.prefix.outputs.prefix }}: <タイトルの残りの部分>
+            タイトル: ${{ steps.prefix.outputs.prefix }}: <日本語でのタイトル>
             本文:
             実装内容
 
-            - ${{ steps.prefix.outputs.prefix }}: <変更内容1>
-            - ${{ steps.prefix.outputs.prefix }}: <変更内容2（必要な場合は追加していく）>
+            - ${{ steps.prefix.outputs.prefix }}: <日本語での変更内容1>
+            - ${{ steps.prefix.outputs.prefix }}: <日本語での変更内容2（必要な場合は追加していく）>
             ---
 
             差分:

--- a/.github/workflows/ai-pr-description.yml
+++ b/.github/workflows/ai-pr-description.yml
@@ -2,10 +2,10 @@ name: AI PR Title & Description Generator
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
-  generate-pr-title-description:
+  generate-pr-description:
     permissions:
       contents: read
       pull-requests: write
@@ -42,42 +42,41 @@ jobs:
         uses: actions/ai-inference@v1
         with:
           prompt: |
-            以下はPull Requestの差分です。この内容から、以下の形式でPRのタイトルと説明文を生成してください。
+            以下はPull Requestの差分です。この内容から、${{ github.event.action == 'opened' && 'タイトルと' || '' }}説明文を生成してください。
             必ず日本語で出力してください。
 
             【制約事項】
-            - タイトル: "${{ steps.prefix.outputs.prefix }}: " で始まる一行の日本語の文章
-            - 本文: 「実装内容」という見出しの下に、変更内容を箇条書きで記載
+            ${{ github.event.action == 'opened' && '- タイトル: "${{ steps.prefix.outputs.prefix }}: " で始まる一行の日本語の文章' || '' }}
+            - 「実装内容」という見出しの下に、変更内容を箇条書きで記載
             - 各箇条書きの項目は "${{ steps.prefix.outputs.prefix }}: " で始める
             - 説明は簡潔に
             - すべての説明は日本語で記述する
 
             【出力フォーマット】
-            ---
-            タイトル: ${{ steps.prefix.outputs.prefix }}: <日本語でのタイトル>
-            本文:
+            ${{ github.event.action == 'opened' && 'タイトル: ${{ steps.prefix.outputs.prefix }}: <日本語でのタイトル>' || '' }}
+            ${{ github.event.action == 'opened' && '本文:' || '' }}
             実装内容
 
             - ${{ steps.prefix.outputs.prefix }}: <日本語での変更内容1>
             - ${{ steps.prefix.outputs.prefix }}: <日本語での変更内容2（必要な場合は追加していく）>
-            ---
 
             差分:
             ${{ steps.diff.outputs.diff }}
 
-      - name: Parse AI Output
-        id: parse
+      - name: Update PR Title & Description
         run: |
           echo "${{ steps.ai.outputs.response }}" > pr_body.txt
-          TITLE=$(grep '^タイトル:' pr_body.txt | sed 's/タイトル: //')
-          BODY=$(sed '1,/^本文:/d' pr_body.txt)
-          echo "$TITLE" > pr_title.txt
-          echo "$BODY" > pr_body.txt
-
-      - name: Update PR Title & Body (gh cli)
-        run: |
-          gh pr edit ${{ github.event.pull_request.number }} \
-            --title "$(cat pr_title.txt)" \
-            --body "$(cat pr_body.txt)"
+          if [ "${{ github.event.action }}" = "opened" ]; then
+            # PR作成時はタイトルも更新
+            TITLE=$(grep '^タイトル:' pr_body.txt | sed 's/タイトル: //')
+            BODY=$(sed '1,/^実装内容/d' pr_body.txt)
+            gh pr edit ${{ github.event.pull_request.number }} \
+              --title "$TITLE" \
+              --body "$BODY"
+          else
+            # push時は本文のみ更新
+            gh pr edit ${{ github.event.pull_request.number }} \
+              --body "$(cat pr_body.txt)"
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
実装内容

- chore: pull_requestイベントの種類にsynchronizeを追加
- chore: ジョブ名をgenerate-pr-descriptionに変更
- chore: ブランチ名からプレフィックスを抽出するステップを追加
- chore: PR作成時と更新時でタイトルと本文の管理を分岐する処理を追加
- chore: AIの出力内容をタイトルと本文に分割して設定する処理を追加